### PR TITLE
fixed uri problem on Windows

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -182,6 +182,7 @@ function getWorkspacePathToFile(doc: {uri: string}): string|undefined {
   if (!match || !match[1] || !workspaceRoot) {
     return undefined;
   }
+  match[1] = match[1].replace(/^\/(\D)(\%3A\/)/,'$1:/') //convert %3A to : only if uri starts /[letter]%3A/
   return path.relative(workspaceRoot, match[1]);
 }
 


### PR DESCRIPTION
Fix #9 

In Windows, VSCode passed down an uri of a document that has been encoded.
for example:
doc.uri = 'file:///c%3A/project'
doc.uri.match(/^file:\/\/(.*)/) returns match[1] = '/c%3A/project'
match[1] should be 'c:/project' before passed to path.relative

