### PR TITLE
Never reject in a vscode callback.

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Add an icon.
 
+### Fixed
+* Internal errors no longer cause an intrusive popup. They instead log to the plugin's output tray.
+
 ## [0.1.1] - 2016-10-25
 
 ### Fixed

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,6 @@
   "scripts": {
     "compile": "installServerIntoExtension ../client ./package.json ./tsconfig.json && tsc -p .",
     "watch": "installServerIntoExtension ../client ./package.json ./tsconfig.json && tsc --watch -p .",
-    "format": "clang-format -i src/*"
+    "format": "clang-format --style=file -i src/*"
   }
 }


### PR DESCRIPTION
It brings up an annoying popup. Instead, log the error, which is still accessible.

Fixes https://github.com/Polymer/vscode-plugin/issues/10 and https://github.com/Polymer/vscode-plugin/issues/15