### PR TITLE
Fix TextDocumentWillSaveEvent err for vsce package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "icon": "polymer.png",
     "publisher": "polymer",
     "engines": {
-        "vscode": "^1.4.0"
+        "vscode": "^1.6.0"
     },
     "categories": [],
     "repository": {


### PR DESCRIPTION
When running `vsce package`, the command failed with:

> Namespace 'vscode' has no exported member 'TextDocumentWillSaveEvent'

The fix is to update the vscode engine from ^1.4.0 to ^1.6.0 per:
https://github.com/Microsoft/vscode-languageserver-node/issues/147

 - [ ] CHANGELOG.md has been updated
