### PR TITLE
Prepare to release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 <!--## [Unreleased]-->
 
+## 0.4.3 - 2017-03-20
+
+* Added many more lint rules.
+* Fixed a number of issues around recognizing Polymer 2.0 element declaration patterns. e.g. https://github.com/Polymer/vscode-plugin/issues/54 and https://github.com/Polymer/vscode-plugin/issues/53
+
 ## 0.4.2 - 2017-03-02
 
 ### Fixed


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated

All the changes are in the editor service, so this is just documenting the fun new stuff in the CHANGELOG, and a fresh npm install.